### PR TITLE
Swap the integral order to make things faster

### DIFF
--- a/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
+++ b/roofit/histfactory/src/HistoToWorkspaceFactoryFast.cxx
@@ -793,7 +793,7 @@ namespace HistFactory{
     tot.specialIntegratorConfig(kTRUE)->method1D().setLabel("RooBinIntegrator")  ;
     tot.specialIntegratorConfig(kTRUE)->method2D().setLabel("RooBinIntegrator")  ;
     tot.specialIntegratorConfig(kTRUE)->methodND().setLabel("RooBinIntegrator")  ;
-    tot.forceNumInt();
+    // tot.forceNumInt();
 
     // for mixed generation in RooSimultaneous
     tot.setAttribute("GenerateBinned"); // for use with RooSimultaneous::generate in mixed mode


### PR DESCRIPTION
As explained by Phoebe:

> so tot here is the RooRealSumPdf containing the sum over (sample HistFunc OR PiecewiseInterp) x (sample normalization)  and calling forceNumInt() forces RooFit to do the integral by evaluating the sum in each bin. This could be faster, in principle, but under the hood we always have a RooDataHist for each sample (either through the HistFunc or through the PiecewiseInterp cache) and integrating those is trivial (RooDataHist::sum(), essentially) so we always want to be decomposing this sum if we can

Forcing the integral is slower because:
> it forces a loop over bins where for each bin you have to eventually address every RooDataHist anyway
> so you call `RooHistFunc::get(i); RooHistFunc::Weight()` Nbins times, instead of calling `RooHistFunc::sum()` once for each sample

The main idea is:
> loop interchange to improve locality of reference
